### PR TITLE
Fixed county filtering

### DIFF
--- a/src/components/FormCoverage.js
+++ b/src/components/FormCoverage.js
@@ -4,7 +4,6 @@ import _drop from 'lodash/drop';
 import _capitalize from 'lodash/capitalize';
 import _sortBy from 'lodash/sortBy';
 import _values from 'lodash/values';
-import PropTypes from 'prop-types';
 import React, {useState} from 'react';
 import {Checkbox, Stack, Input, FormControl, FormLabel} from '@chakra-ui/core';
 import Select from 'react-select';
@@ -71,8 +70,9 @@ const USStateOptions = _values(USStates).map(state => ({value: state, label: sta
 const CanadianProvinceOptions = _values(CanadianProvinces).map(province => ({value: province.name, label: province.name}));
 const USCountyOptions = areaCoverageProperties.filter(prop => prop.startsWith('service-county'));
 
-function countyToLabel(county){
-  return _capitalize(_drop(county.split('-'), 3).join(' '));
+function countyToLabel(state, county){
+  const prefix = 'service-county-' + state;
+  return _capitalize(county.slice(prefix.length).split('-').join(' ').trim());
 }
 
 const USPicker = (props) => {
@@ -82,12 +82,13 @@ const USPicker = (props) => {
   const [county, setCounty] = useState(null);
   const [town, setTown] = useState(null);
   const cityOptions = USCities[state?.value]?.map(city => ({value: city, label: city})) ?? [];
+
   const countyOptions = USCountyOptions.filter(county => {
-    return county.startsWith(`service-county-${state?.value.toLowerCase()}`);
+    return county.startsWith(`service-county-${state?.value.toLowerCase().split(' ').join('-')}`);
   }).map(county => {
     return {
-      value: countyToLabel(county),
-      label: countyToLabel(county)
+      value: countyToLabel(state?.value, county),
+      label: countyToLabel(state?.value, county)
     };
   });
   return (


### PR DESCRIPTION
## Description 
County filtering was broken for states with spaces in the name, such as "New York" or "New Mexico". That's why no counties were appearing for those states. 

## Asana Ticket
https://app.asana.com/0/1132189118126148/1186477952470218

## PR Checklist
- [x] Assign @ShehryarKh as a reviewer.
- [x] If your PR is not a hotfix, is it targeted for dev?
- [ ] Unit and functional test coverage was added where applicable.
- [ ] CI/CD passes for your PR.
- [ ] Complex code is well documented with comments.
- [x] Does the original ticket have test instructions? If not add them below

## How to Test
These changes only effect the US Picker. The easiest way to test is to try selecting counties for "New York" and for a single word state like "Alaska". 

![Screenshot from 2020-07-28 22-06-33](https://user-images.githubusercontent.com/18703/88759199-1aada380-d11f-11ea-9cca-ddfc287c6ae7.png)
