### PR TITLE
Adds new "Sponsors" subcategory to "Community Support" category on the U.S. Catalog

### DIFF
--- a/src/data/tags.json
+++ b/src/data/tags.json
@@ -107,7 +107,7 @@
     "Transporte": ["Pases de transporte y descuentos", "Ayuda con transporte"]
   },
   "united_states": {
-    "Community Support": ["Cultural centers", "LGBTQ centers"],
+    "Community Support": ["Cultural centers", "LGBTQ centers", "Sponsors"],
     "Computers and Internet": [],
     "Education and Employment": [
       "Career counseling",


### PR DESCRIPTION
## Description

Adds new "Sponsors" subcategory to "Community Support" category on the U.S. Catalog

- Asana ticket: https://app.asana.com/0/1132189118126148/1186705589820009/f

## PR Checklist

<!-- Please validate your changes with the checklist below before marking for code review. -->

- [x] If your PR is not a hotfix, is it targeted for `dev`?
- [x] Unit and functional test coverage was added where applicable.
- [x] CI/CD passes for your PR.
- [x] Complex code is well documented with comments.
- [x] Does the original ticket have test instructions? If not add them below

## How to Test

<!-- Provide instructions for how to test/validate the changes. -->

1. Navigate to 'Organizations' page in control panel
2. Select an organization based in the US; click "View"
3. Scroll down the page to the "Services" section.
4. Select a service and click "View"
5. Click on the "Tags" item in the tab menu
6. Locate "United States Tags" and click "Edit Tags"
7. Check option for Community Support > Sponsors
8. Click Save
9. Verify the organization appears in the search results when you select Service Type > Community Support > Sponsors in the US catalog