### PR TITLE
Fix: Page should be displayed in Spanish when user clicks 'Español' option

### DIFF
--- a/src/pages/Organization.js
+++ b/src/pages/Organization.js
@@ -360,7 +360,7 @@ const Organization = (props) => {
               text: 'English',
             },
             {
-              href: `${catalogUrl}/es_MX/resource/${slug_ES}`,
+              href: `${catalogUrl}/en_MX/resource/${slug_ES}#googtrans(es)`,
               text: 'Español',
             },
           ]}


### PR DESCRIPTION
…panol' option

## Description

Adds fix so catalog page is displayed in spanish when user clicks 'Espanol' option

- Asana ticket:

## PR Checklist

<!-- Please validate your changes with the checklist below before marking for code review. -->

- [x] If your PR is not a hotfix, is it targeted for `dev`?
- [x] Unit and functional test coverage was added where applicable.
- [x] CI/CD passes for your PR.
- [x] Complex code is well documented with comments.
- [x] Does the original ticket have test instructions? If not add them below

## How to Test

Navigate to catalog homepage
Search for an organization in Mexico
Click "View on Catalog"
Select 'Español' option
Verify that organization page on catalog is displayed in Spanish
