### PR TITLE
removes distrito federal from mexico states dropdown

### DIFF
--- a/src/data/mexican-cities.json
+++ b/src/data/mexican-cities.json
@@ -1863,118 +1863,6 @@
       "initials": ""
     },
     {
-      "id": "266",
-      "state_id": "9",
-      "key": "002",
-      "name": "Azcapotzalco",
-      "initials": ""
-    },
-    {
-      "id": "267",
-      "state_id": "9",
-      "key": "003",
-      "name": "Coyoacán",
-      "initials": ""
-    },
-    {
-      "id": "268",
-      "state_id": "9",
-      "key": "004",
-      "name": "Cuajimalpa de Morelos",
-      "initials": ""
-    },
-    {
-      "id": "269",
-      "state_id": "9",
-      "key": "005",
-      "name": "Gustavo A. Madero",
-      "initials": ""
-    },
-    {
-      "id": "270",
-      "state_id": "9",
-      "key": "006",
-      "name": "Iztacalco",
-      "initials": ""
-    },
-    {
-      "id": "271",
-      "state_id": "9",
-      "key": "007",
-      "name": "Iztapalapa",
-      "initials": ""
-    },
-    {
-      "id": "272",
-      "state_id": "9",
-      "key": "008",
-      "name": "La Magdalena Contreras",
-      "initials": ""
-    },
-    {
-      "id": "273",
-      "state_id": "9",
-      "key": "009",
-      "name": "Milpa Alta",
-      "initials": ""
-    },
-    {
-      "id": "274",
-      "state_id": "9",
-      "key": "010",
-      "name": "Álvaro Obregón",
-      "initials": ""
-    },
-    {
-      "id": "275",
-      "state_id": "9",
-      "key": "011",
-      "name": "Tláhuac",
-      "initials": ""
-    },
-    {
-      "id": "276",
-      "state_id": "9",
-      "key": "012",
-      "name": "Tlalpan",
-      "initials": ""
-    },
-    {
-      "id": "277",
-      "state_id": "9",
-      "key": "013",
-      "name": "Xochimilco",
-      "initials": ""
-    },
-    {
-      "id": "278",
-      "state_id": "9",
-      "key": "014",
-      "name": "Benito Juárez",
-      "initials": ""
-    },
-    {
-      "id": "279",
-      "state_id": "9",
-      "key": "015",
-      "name": "Cuauhtémoc",
-      "initials": ""
-    },
-    {
-      "id": "280",
-      "state_id": "9",
-      "key": "016",
-      "name": "Miguel Hidalgo",
-      "initials": ""
-    },
-    {
-      "id": "281",
-      "state_id": "9",
-      "key": "017",
-      "name": "Venustiano Carranza",
-      "initials": ""
-    },
-    {
       "id": "282",
       "state_id": "10",
       "key": "001",
@@ -17449,6 +17337,118 @@
       "state_id": "32",
       "key": "058",
       "name": "Santa María de la Paz",
+      "initials": ""
+    },
+    {
+      "id": "266",
+      "state_id": "33",
+      "key": "002",
+      "name": "Azcapotzalco",
+      "initials": ""
+    },
+    {
+      "id": "267",
+      "state_id": "33",
+      "key": "003",
+      "name": "Coyoacán",
+      "initials": ""
+    },
+    {
+      "id": "268",
+      "state_id": "33",
+      "key": "004",
+      "name": "Cuajimalpa de Morelos",
+      "initials": ""
+    },
+    {
+      "id": "269",
+      "state_id": "33",
+      "key": "005",
+      "name": "Gustavo A. Madero",
+      "initials": ""
+    },
+    {
+      "id": "270",
+      "state_id": "33",
+      "key": "006",
+      "name": "Iztacalco",
+      "initials": ""
+    },
+    {
+      "id": "271",
+      "state_id": "33",
+      "key": "007",
+      "name": "Iztapalapa",
+      "initials": ""
+    },
+    {
+      "id": "272",
+      "state_id": "33",
+      "key": "008",
+      "name": "La Magdalena Contreras",
+      "initials": ""
+    },
+    {
+      "id": "273",
+      "state_id": "33",
+      "key": "009",
+      "name": "Milpa Alta",
+      "initials": ""
+    },
+    {
+      "id": "274",
+      "state_id": "33",
+      "key": "010",
+      "name": "Álvaro Obregón",
+      "initials": ""
+    },
+    {
+      "id": "275",
+      "state_id": "33",
+      "key": "011",
+      "name": "Tláhuac",
+      "initials": ""
+    },
+    {
+      "id": "276",
+      "state_id": "33",
+      "key": "012",
+      "name": "Tlalpan",
+      "initials": ""
+    },
+    {
+      "id": "277",
+      "state_id": "33",
+      "key": "013",
+      "name": "Xochimilco",
+      "initials": ""
+    },
+    {
+      "id": "278",
+      "state_id": "33",
+      "key": "014",
+      "name": "Benito Juárez",
+      "initials": ""
+    },
+    {
+      "id": "279",
+      "state_id": "33",
+      "key": "015",
+      "name": "Cuauhtémoc",
+      "initials": ""
+    },
+    {
+      "id": "280",
+      "state_id": "33",
+      "key": "016",
+      "name": "Miguel Hidalgo",
+      "initials": ""
+    },
+    {
+      "id": "281",
+      "state_id": "33",
+      "key": "017",
+      "name": "Venustiano Carranza",
       "initials": ""
     }
   ]

--- a/src/data/mexican-states.json
+++ b/src/data/mexican-states.json
@@ -55,12 +55,6 @@
       "shortname": "Chih."
     },
     {
-      "id": "9",
-      "key": "09",
-      "name": "Distrito Federal",
-      "shortname": "DF"
-    },
-    {
       "id": "10",
       "key": "10",
       "name": "Durango",


### PR DESCRIPTION
## Description

removes distrito federal (DF) from mexico states dropdown. reassociates DF neighbourhoods with Mexico city state.

- Asana ticket:
https://app.asana.com/0/1132189118126148/1199102509565053/f

## PR Checklist

<!-- Please validate your changes with the checklist below before marking for code review. -->

- [x] If your PR is not a hotfix, is it targeted for `dev`?
- [ ] Unit and functional test coverage was added where applicable.
- [x] CI/CD passes for your PR.
- [x] Complex code is well documented with comments.
- [x] Does the original ticket have test instructions? If not add them below

## How to Test
Navigate to control panel
Log in
Click "view" to view an organization
Scroll down to "Service Coverage Areas"
Click "edit coverage"
Select "Mexico" from country dropdown
Observe that "Distrito Federal" is not present in list
Select "Mexico City"
Observe that City options are now available. These should be the same as those previously associated with Distrito Federal

<img width="499" alt="Screenshot 2020-11-08 at 11 33 09 AM" src="https://user-images.githubusercontent.com/7406914/98470907-b470fc00-21b6-11eb-8adc-31121f61ec64.png">

<img width="601" alt="image" src="https://user-images.githubusercontent.com/7406914/98470939-d4082480-21b6-11eb-9e8d-4c3870dac172.png">

<img width="506" alt="Screenshot 2020-11-08 at 11 35 11 AM" src="https://user-images.githubusercontent.com/7406914/98470899-ab802a80-21b6-11eb-8273-123f157e0249.png">

<img width="592" alt="Screenshot 2020-11-08 at 11 38 57 AM" src="https://user-images.githubusercontent.com/7406914/98470971-13367580-21b7-11eb-9c1d-23e617cf0c3e.png">

<img width="543" alt="Screenshot 2020-11-08 at 11 39 13 AM" src="https://user-images.githubusercontent.com/7406914/98470974-1af61a00-21b7-11eb-879e-19f8b646685e.png">


