### PR TITLE
adds cities in vermont

### DIFF
--- a/src/data/us-cities.json
+++ b/src/data/us-cities.json
@@ -1100,6 +1100,14 @@
     "Huntington"
   ],
   "Vermont": [
-    "Burlington"
+    "Barre",
+    "Burlington",
+    "Montpelier",
+    "Newport",
+    "Rutland",
+    "South Burlington",
+    "St. Albans",
+    "Vergennes",
+    "Winooski"
   ]
 }


### PR DESCRIPTION
## Description

- adds cities in vermont

## Asana ticket: 
https://app.asana.com/0/1132189118126148/1199357026467349/f

## PR Checklist

<!-- Please validate your changes with the checklist below before marking for code review. -->

- [x] Assign @FJKhan **and** @Alfredo-Moreira as reviewers.
- [x] If your PR is not a hotfix, is it targeted for `dev`? If your PR is a hotfix, is it targeted for `master`?
- [ ] Unit and functional test coverage was added where applicable.
- [x] CI/CD passes for your PR.
- [ ] Complex code is well documented with comments.
- [x] Does the original ticket have test instructions? If not add them below

## How to Test

1. Navigate to control panel
2. Log in
3. Navigate to an org page (Click "view")
4. Scroll down to "Service Coverage" section. Click "Edit Coverage"
5. Select the following options: Country: USA, State: Vermont
6. Verify that city dropdown is being populated with added values -- not just "Burlington"

![image](https://user-images.githubusercontent.com/7406914/122591326-d1b15700-d030-11eb-81e0-e2b900842621.png)
