### PR TITLE
add COVID-19 as a sub category

### DIFF
--- a/src/data/tags.json
+++ b/src/data/tags.json
@@ -31,6 +31,7 @@
       "Legal hotlines"
     ],
     "Medical": [
+      "COVID-19 services",
       "Medical clinics",
       "Women's health",
       "HIV and sexual health",
@@ -84,6 +85,7 @@
       "Name and gender change"
     ],
     "Medical": [
+      "COVID-19 services",
       "Dental care",
       "HIV and sexual health",
       "Medical clinics",
@@ -141,6 +143,7 @@
     ],
     "Mail": [],
     "Medical": [
+      "COVID-19 services",
       "Dental care",
       "HIV and sexual health",
       "Medical clinics",


### PR DESCRIPTION
## Description
add COVID-19 as a sub category

* Note this PR needs the matching PR for Catalog, https://github.com/asylum-connect/asylumconnect-catalog/pull/198

## Asana ticket:
https://app.asana.com/0/1132189118126148/1201731585269565

## PR Checklist

<!-- Please validate your changes with the checklist below before marking for code review. -->

- [ ] Assign @FJKhan **and** @Alfredo-Moreira as reviewers.
- [ ] If your PR is not a hotfix, is it targeted for `dev`? If your PR is a hotfix, is it targeted for `master`?
- [ ] Unit and functional test coverage was added where applicable.
- [ ] CI/CD passes for your PR.
- [ ] Complex code is well documented with comments.
- [ ] Does the original ticket have test instructions? If not add them below

## How to Test

1. using control panel (or manually via the DB) add COVID-19 services as a subtype under Medical for an organization
2. from the Catalog front end, Select COVID-19 service under Search Filter
3. expect the above org to be found