### PR TITLE
change 'Abortion Services' to 'Abortion services' so the title matches other services - lower case 's'

### DIFF
--- a/src/data/tags.json
+++ b/src/data/tags.json
@@ -31,7 +31,7 @@
       "Legal hotlines"
     ],
     "Medical": [
-      "Abortion Services",
+      "Abortion services",
       "COVID-19 services",
       "Dental care",
       "HIV and sexual health",
@@ -86,7 +86,7 @@
       "Name and gender change"
     ],
     "Medical": [
-      "Abortion Services",
+      "Abortion services",
       "COVID-19 services",
       "Dental care",
       "HIV and sexual health",
@@ -145,7 +145,7 @@
     ],
     "Mail": [],
     "Medical": [
-      "Abortion Services",
+      "Abortion services",
       "COVID-19 services",
       "Dental care",
       "HIV and sexual health",


### PR DESCRIPTION
## this should be done in conjunction with the associated API pr and should be merged Before the API PR
https://github.com/asylum-connect/inreach-api/pull/143

## Description
organizations with the Abortion service tag where not appearing in the catalog search results.

The root cause was because when the front end was changed from 'Abortion Services' to 'Abortion services' (lower case 's') the control-panel field names where not changed to match, nor was the DB schema updated.

This ticket is part one of the change - to update the field names within control panel

## Asana ticket:

## PR Checklist

<!-- Please validate your changes with the checklist below before marking for code review. -->

- [ ] Assign @trigal2012 **and** @Alfredo-Moreira as reviewers.
- [ ] If your PR is not a hotfix, is it targeted for `dev`? If your PR is a hotfix, is it targeted for `master`?
- [ ] Unit and functional test coverage was added where applicable.
- [ ] CI/CD passes for your PR.
- [ ] Complex code is well documented with comments.
- [ ] Does the original ticket have test instructions? If not add them below

## How to Test

<!-- Provide instructions for how to test/validate the changes. -->
