### PR TITLE
add claimed filter to organization filter form

### DIFF
--- a/cypress/support/reusable_tests/dashboard.js
+++ b/cypress/support/reusable_tests/dashboard.js
@@ -126,6 +126,12 @@ Cypress.Commands.add('testDashboardElements',(viewport, creds)=>{
         expect($element.children()).contain('Published');
     });
 
+        cy.getElementByTestId('filter-claim-status-switch').then($element=>{
+        expect($element).to.be.visible;
+        expect($element).to.have.attr('type','checkbox');
+        expect($element.children()).contain('Claimed');
+    });
+
     cy.getElementByTestId('filter-properties-label').then($element=>{
         expect($element).to.be.visible;
         expect($element).contain('Properties:');

--- a/src/components/FiltersOrganizations.js
+++ b/src/components/FiltersOrganizations.js
@@ -102,6 +102,7 @@ const FiltersOrganizations = (props) => {
   const [tagLocale, setTagLocale] = useInputChange('united_states');
   const [properties, setProperties] = useState({});
   const [isPublished, setPublishedStatus] = useState(true);
+  const [isClaimed, setClaimedStatus] = useState(true);
   const [tags, setTags] = useState([]);
   const [lastVerified, setLastVerified] = useState('');
   const [lastVerifiedStart, setLastVerifiedStart] = useState('');
@@ -134,6 +135,9 @@ const FiltersOrganizations = (props) => {
   };
 
   const handlePublishChange = (ev) => setPublishedStatus(ev.target.checked);
+
+  const handleClaimChange = (ev) => setClaimedStatus(ev.target.checked);
+
   const handleSelect = (type) => (ev) => {
     const value = ev.target.value;
 
@@ -176,12 +180,16 @@ const FiltersOrganizations = (props) => {
       createdAtEnd,
     };
 
-    if (serviceArea) {
+    if (serviceArea?.length > 0) {
       query.serviceArea = serviceArea;
     }
 
     if (!isPublished) {
       query.pending = 'true';
+    }
+
+    if (!isClaimed) {
+      query.pendingOwnership = 'true';
     }
 
     if (lastVerified) {
@@ -211,7 +219,6 @@ const FiltersOrganizations = (props) => {
     if (createdAtEnd) {
       query.createdAtEnd = new Date(createdAtEnd).toISOString();
     }
-
     updateQuery(query);
   };
 
@@ -283,7 +290,9 @@ const FiltersOrganizations = (props) => {
             Select Service Areas
           </Button>
         </Flex>
+        
         <ListServiceArea properties={coverageAreaProperties} />
+
         <Flex mt={[0, '2rem !important']}>
           <Box>
             <Text data-test-id="filter-last-verified-label">
@@ -509,20 +518,40 @@ const FiltersOrganizations = (props) => {
           </Flex>
         )}
 
-        <Text
-          mt={[0, '2rem !important']}
-          data-test-id="filter-publish-status-label"
-        >
-          Publish Status:
-        </Text>
-        <Checkbox
-          data-test-id="filter-publish-status-switch"
-          isChecked={isPublished}
-          onChange={handlePublishChange}
-          type="checkbox"
-        >
-          Published
-        </Checkbox>
+        <Flex mt={[0, '2rem !important']} alignItems="center" justifyContent="space-between">
+          <Text
+            data-test-id="filter-publish-status-label"
+          >
+            Publish Status:
+          </Text>
+          <Checkbox
+            data-test-id="filter-publish-status-switch"
+            isChecked={isPublished}
+            onChange={handlePublishChange}
+            type="checkbox"
+          >
+            Published
+          </Checkbox>
+        </Flex>
+
+        <Flex mt={[0, '2rem !important']} alignItems="center" justifyContent="space-between">
+          <Text
+            data-test-id="filter-claim-status-label"
+          >
+            Claimed Status:
+          </Text>
+          <Checkbox
+            data-test-id="filter-claim-status-switch"
+            isChecked={isClaimed}
+            onChange={handleClaimChange}
+            type="checkbox"
+          >
+            Claimed
+          </Checkbox>
+        </Flex>
+
+        <Spacer />
+
         <Text data-test-id="filter-properties-label">Properties:</Text>
         <Select
           data-test-id="filter-drop-down-property"

--- a/src/components/Table.js
+++ b/src/components/Table.js
@@ -58,7 +58,6 @@ const ActioSpan = styled(Text)`
 
 const Table = (props) => {
   const {actions, getRowLink, headers, hideHeaders, isKeyValue, rows, tableDataTestId} = props;
-  console.log(rows);
   return (
     <StyledTable data-test-id={tableDataTestId}>
       {isKeyValue && (

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -83,6 +83,7 @@ export const getOrgQueryUrls = (query) => {
     name,
     page,
     pending,
+    pendingOwnership,
     properties,
     serviceArea,
     tags,
@@ -111,6 +112,10 @@ export const getOrgQueryUrls = (query) => {
 
   if (pending) {
     queryParam += '&pending=true';
+  }
+
+  if (pendingOwnership) {
+    queryParam += '&pendingOwnership=true';
   }
 
   if (verified) {


### PR DESCRIPTION
## Description

- added claimed filter to organization filter form
- the filter is of the type checkbox
- the checkbox is selected by default - which means organizations with Approved owners should be returned by the search

**This PR has a sibling PR for the API** - https://github.com/asylum-connect/inreach-api/pull/166

## Asana ticket:
https://app.asana.com/0/1132189118126148/1199612928739230/f

## PR Checklist

<!-- Please validate your changes with the checklist below before marking for code review. -->

- [ ] Assign @trigal2012 **and** @Alfredo-Moreira as reviewers.
- [ ] If your PR is not a hotfix, is it targeted for `dev`? If your PR is a hotfix, is it targeted for `master`?
- [ ] Unit and functional test coverage was added where applicable.
- [ ] CI/CD passes for your PR.
- [ ] Complex code is well documented with comments.
- [ ] Does the original ticket have test instructions? If not add them below

## How to Test
**Claimed box selected**
1. from control panel home page
2. In the Filter form, ensure the "Claimed" checkbox is ticked, click the search button
3. search results should return all organizations with approved owners (there are users in the owners array, these uses will appear in the affiliates section of the organization details)
4. the query url should not contain the 'pendingOwnership' parameter

**Claimed box Not selected**
1. from control panel home page
2. In the Filter form, ensure the "Claimed" checkbox is not ticked, click the search button
3. search results should return all organizations with un-approved owners (the un-approved owners should appear in the Admin/Suggestion/Pending owners tab)
4. the query url should contain the 'pendingOwnership=false' parameter
