### PR TITLE
Feature - Data Portal - Claimed Status has four options (Claimed, Not Claimed, Pending, All)

### DIFF
--- a/src/components/FiltersOrganizations.js
+++ b/src/components/FiltersOrganizations.js
@@ -192,7 +192,7 @@ const FiltersOrganizations = (props) => {
       query.pending = 'true';
     }
 
-    if (claimedStatus) {
+    if (claimedStatus && claimedStatus != 'all') {
       query.claimedStatus = claimedStatus;
     }
 

--- a/src/components/FiltersOrganizations.js
+++ b/src/components/FiltersOrganizations.js
@@ -8,6 +8,8 @@ import {
   Checkbox,
   Flex,
   Input,
+  Radio,
+  RadioGroup,
   Select,
   Spacer,
   Stack,
@@ -102,7 +104,7 @@ const FiltersOrganizations = (props) => {
   const [tagLocale, setTagLocale] = useInputChange('united_states');
   const [properties, setProperties] = useState({});
   const [isPublished, setPublishedStatus] = useState(true);
-  const [isClaimed, setClaimedStatus] = useState(true);
+  const [claimedStatus, setClaimedStatus] = useState('all');
   const [tags, setTags] = useState([]);
   const [lastVerified, setLastVerified] = useState('');
   const [lastVerifiedStart, setLastVerifiedStart] = useState('');
@@ -136,7 +138,9 @@ const FiltersOrganizations = (props) => {
 
   const handlePublishChange = (ev) => setPublishedStatus(ev.target.checked);
 
-  const handleClaimChange = (ev) => setClaimedStatus(ev.target.checked);
+  const handleClaimChange = (ev) => {
+    setClaimedStatus(ev.target.value);
+  }
 
   const handleSelect = (type) => (ev) => {
     const value = ev.target.value;
@@ -188,8 +192,8 @@ const FiltersOrganizations = (props) => {
       query.pending = 'true';
     }
 
-    if (!isClaimed) {
-      query.pendingOwnership = 'true';
+    if (claimedStatus) {
+      query.claimedStatus = claimedStatus;
     }
 
     if (lastVerified) {
@@ -548,15 +552,15 @@ const FiltersOrganizations = (props) => {
           >
             Claimed Status:
           </Text>
-          <Checkbox
-            data-test-id="filter-claim-status-switch"
-            isChecked={isClaimed}
-            onChange={handleClaimChange}
-            type="checkbox"
-          >
-            Claimed
-          </Checkbox>
         </Flex>
+          <RadioGroup onChange={setClaimedStatus} value={claimedStatus}>
+            <Stack direction='row'>
+              <Radio value='claimed'><Text fontSize="xs">Claimed</Text></Radio>
+              <Radio value='notClaimed'><Text fontSize="xs">Not Claimed</Text></Radio>
+              <Radio value='pending'><Text fontSize="xs">Pending</Text></Radio>
+              <Radio value='all'><Text fontSize="xs">All</Text></Radio>
+            </Stack>
+          </RadioGroup>
 
         <Spacer />
 

--- a/src/components/FiltersOrganizations.js
+++ b/src/components/FiltersOrganizations.js
@@ -631,6 +631,9 @@ const FiltersOrganizations = (props) => {
             Search
           </Button>
         </Box>
+        <Text fontSize="xs">
+          Any organization that has been 'soft deleted' will not appear in this list. They can be seen in the 'Trash Bin' of the Admin view.
+        </Text>
       </Stack>
     </form>
   );

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -85,6 +85,7 @@ export const getOrgQueryUrls = (query) => {
     page,
     pending,
     pendingOwnership,
+    claimedStatus,
     properties,
     serviceArea,
     tags,
@@ -115,8 +116,8 @@ export const getOrgQueryUrls = (query) => {
     queryParam += '&pending=true';
   }
 
-  if (pendingOwnership) {
-    queryParam += '&pendingOwnership=true';
+  if (claimedStatus) {
+    queryParam += `&claimedStatus=${claimedStatus}`;
   }
 
   if (verified) {

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -116,6 +116,10 @@ export const getOrgQueryUrls = (query) => {
     queryParam += '&pending=true';
   }
 
+  if (pendingOwnership) {
+    queryParam += '&pendingOwnership=true';
+  }
+
   if (claimedStatus) {
     queryParam += `&claimedStatus=${claimedStatus}`;
   }


### PR DESCRIPTION
## Description
to better support the Claimed status for organizations it is necessary to have 4 options not just true/false.

Changed Claimed Status filter option to a radio button list
options are:

- Claimed: (in the DB, for any organization, there is at least one value in the owners array with isApproved property set to true)
- Not Claimed:(in the DB, for any organization, the owners.isApproved property does not exists or exists and is null)
- Pending: (in the DB, for any organization, there is at least one value in the owners array with the isApproved property set to false)
- All: (if All is selected, don't filter organizations on the owners array at all)

*Note - this change has an associated API change - https://github.com/asylum-connect/inreach-api/pull/184
## Asana ticket:
https://app.asana.com/0/1132189118126148/1202888514658082

## PR Checklist

<!-- Please validate your changes with the checklist below before marking for code review. -->

- [ ] Assign @trigal2012 **and** @Alfredo-Moreira as reviewers.
- [ ] If your PR is not a hotfix, is it targeted for `dev`? If your PR is a hotfix, is it targeted for `master`?
- [ ] Unit and functional test coverage was added where applicable.
- [ ] CI/CD passes for your PR.
- [ ] Complex code is well documented with comments.
- [ ] Does the original ticket have test instructions? If not add them below

## How to Test

<!-- Provide instructions for how to test/validate the changes. -->
